### PR TITLE
test: add interleaved table tests

### DIFF
--- a/Google.Cloud.Spanner.NHibernate.IntegrationTests/Google.Cloud.Spanner.NHibernate.IntegrationTests.csproj
+++ b/Google.Cloud.Spanner.NHibernate.IntegrationTests/Google.Cloud.Spanner.NHibernate.IntegrationTests.csproj
@@ -21,6 +21,9 @@
 
     <ItemGroup>
       <None Remove="SampleDataModel.sql" />
+      <Content Include="InterleavedTableTests\InterleavedTableDataModel.sql">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </Content>
       <Content Include="SampleDataModel.sql">
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       </Content>

--- a/Google.Cloud.Spanner.NHibernate.IntegrationTests/InterleavedTableTests/Entities/Album.cs
+++ b/Google.Cloud.Spanner.NHibernate.IntegrationTests/InterleavedTableTests/Entities/Album.cs
@@ -1,0 +1,77 @@
+﻿// Copyright 2021 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using NHibernate.Mapping.ByCode.Conformist;
+using System;
+using System.Collections.Generic;
+
+namespace Google.Cloud.Spanner.NHibernate.IntegrationTests.InterleavedTableTests.Entities
+{
+    [Serializable]
+    public class AlbumIdentifier
+    {
+        public AlbumIdentifier()
+        {
+        }
+
+        public AlbumIdentifier(Singer singer)
+        {
+            Singer = singer;
+            AlbumId = Guid.NewGuid().ToString();
+        }
+        
+        public virtual Singer Singer { get; private set; }
+        public virtual string AlbumId { get; private set; }
+
+        public override bool Equals(object other) =>
+            other is AlbumIdentifier ai && Equals(Singer?.SingerId, ai.Singer?.SingerId) && Equals(AlbumId, ai.AlbumId);
+
+        public override int GetHashCode() => Singer?.SingerId?.GetHashCode() ?? 0 | AlbumId?.GetHashCode() ?? 0;
+    }
+    
+    public class Album
+    {
+        public Album()
+        {
+        }
+
+        public virtual AlbumIdentifier AlbumIdentifier { get; set; }
+        public virtual string Title { get; set; }
+        public virtual Singer Singer => AlbumIdentifier?.Singer;
+        public virtual IList<Track> Tracks { get; set; }
+    }
+
+    public class AlbumMapping : ClassMapping<Album>
+    {
+        public AlbumMapping()
+        {
+            Table("Albums");
+            ComponentAsId(x => x.AlbumIdentifier, m =>
+            {
+                m.ManyToOne(a => a.Singer, m => m.Column("SingerId"));
+                m.Property(a => a.AlbumId);
+            });
+            Property(x => x.Title);
+            Bag(x => x.Tracks,
+                c =>
+                {
+                    // Make sure to set Inverse(true) to prevent NHibernate from trying to break the association between
+                    // an Album and a Track by setting Track.AlbumId = NULL.
+                    c.Inverse(true);
+                    c.Key(k => k.Columns(c => c.Name("SingerId"), c => c.Name("AlbumId")));
+                },
+                r => r.OneToMany());
+        }
+    }
+}

--- a/Google.Cloud.Spanner.NHibernate.IntegrationTests/InterleavedTableTests/Entities/Singer.cs
+++ b/Google.Cloud.Spanner.NHibernate.IntegrationTests/InterleavedTableTests/Entities/Singer.cs
@@ -1,0 +1,56 @@
+﻿// Copyright 2021 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using NHibernate.Mapping.ByCode;
+using NHibernate.Mapping.ByCode.Conformist;
+using System.Collections.Generic;
+
+namespace Google.Cloud.Spanner.NHibernate.IntegrationTests.InterleavedTableTests.Entities
+{
+    public class Singer
+    {
+        public Singer()
+        {
+        }
+
+        public virtual string SingerId { get; set; }
+        public virtual string FirstName { get; set; }
+        public virtual string LastName { get; set; }
+        public virtual IList<Album> Albums { get; set; }
+        public virtual IList<Track> Tracks { get; set; }
+    }
+
+    public class SingerMapping : ClassMapping<Singer>
+    {
+        public SingerMapping()
+        {
+            Table("Singers");
+            Id(x => x.SingerId, m => m.Generator(new UUIDHexGeneratorDef()));
+            Property(x => x.FirstName);
+            Property(x => x.LastName);
+            Bag(x => x.Albums, c =>
+            {
+                // Make sure to set Inverse(true) to prevent NHibernate from trying to break the association between
+                // a Singer and an Album by setting Album.SingerId = NULL.
+                c.Inverse(true);
+                c.Key(k => k.Column("SingerId"));
+            }, r => r.OneToMany());
+            Bag(x => x.Tracks, c =>
+            {
+                c.Inverse(true);
+                c.Key(k => k.Column("SingerId"));
+            }, r => r.OneToMany());
+        }
+    }
+}

--- a/Google.Cloud.Spanner.NHibernate.IntegrationTests/InterleavedTableTests/Entities/Track.cs
+++ b/Google.Cloud.Spanner.NHibernate.IntegrationTests/InterleavedTableTests/Entities/Track.cs
@@ -1,0 +1,73 @@
+﻿// Copyright 2021 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using NHibernate.Mapping.ByCode.Conformist;
+using System;
+
+namespace Google.Cloud.Spanner.NHibernate.IntegrationTests.InterleavedTableTests.Entities
+{
+    [Serializable]
+    public class TrackIdentifier
+    {
+        public TrackIdentifier()
+        {
+        }
+
+        public TrackIdentifier(Album album)
+        {
+            Album = album;
+            TrackId = Guid.NewGuid().ToString();
+        }
+        
+        public virtual Album Album { get; private set; }
+        public virtual string TrackId { get; private set; }
+
+        public override bool Equals(object other) =>
+            other is TrackIdentifier ti 
+            && Equals(Album?.AlbumIdentifier?.AlbumId, ti.Album?.AlbumIdentifier?.AlbumId)
+            && Equals(TrackId, ti.TrackId);
+
+        public override int GetHashCode() => 
+            Album?.AlbumIdentifier?.AlbumId?.GetHashCode() ?? 0
+            | TrackId?.GetHashCode() ?? 0;
+    }
+    public class Track
+    {
+        public Track()
+        {
+        }
+
+        public virtual TrackIdentifier TrackIdentifier { get; set; }
+        public virtual string Title { get; set; }
+        public virtual Singer Singer => TrackIdentifier?.Album?.Singer;
+        public virtual Album Album => TrackIdentifier?.Album;
+    }
+
+    public class TrackMapping : ClassMapping<Track>
+    {
+        public TrackMapping()
+        {
+            Table("Tracks");
+            ComponentAsId(x => x.TrackIdentifier, m =>
+            {
+                m.ManyToOne(a => a.Album, mapping => mapping.Columns(
+                    c1 => c1.Name("SingerId"),
+                    c2 => c2.Name("AlbumId")
+                ));
+                m.Property(a => a.TrackId);
+            });
+            Property(x => x.Title);
+        }
+    }
+}

--- a/Google.Cloud.Spanner.NHibernate.IntegrationTests/InterleavedTableTests/InterleavedTableDataModel.sql
+++ b/Google.Cloud.Spanner.NHibernate.IntegrationTests/InterleavedTableTests/InterleavedTableDataModel.sql
@@ -1,0 +1,33 @@
+﻿/* Copyright 2021 Google LLC
+* 
+* Licensed under the Apache License, Version 2.0 (the "License")
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+* 
+*     https://www.apache.org/licenses/LICENSE-2.0
+* 
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+CREATE TABLE Singers (
+  SingerId  STRING(36) NOT NULL,
+  FirstName STRING(200),
+  LastName  STRING(200) NOT NULL,
+) PRIMARY KEY (SingerId);
+
+CREATE TABLE Albums (
+  SingerId STRING(36) NOT NULL,
+  AlbumId  STRING(36) NOT NULL,
+  Title    STRING(100) NOT NULL,
+) PRIMARY KEY (SingerId, AlbumId), INTERLEAVE IN PARENT Singers;
+
+CREATE TABLE Tracks (
+  SingerId STRING(36) NOT NULL,
+  AlbumId  STRING(36) NOT NULL,
+  TrackId  STRING(36) NOT NULL,
+  Title    STRING(200) NOT NULL,
+) PRIMARY KEY (SingerId, AlbumId, TrackId), INTERLEAVE IN PARENT Albums;

--- a/Google.Cloud.Spanner.NHibernate.IntegrationTests/InterleavedTableTests/InterleavedTableTests.cs
+++ b/Google.Cloud.Spanner.NHibernate.IntegrationTests/InterleavedTableTests/InterleavedTableTests.cs
@@ -1,0 +1,188 @@
+// Copyright 2021 Google LLC
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Spanner.Data;
+using Google.Cloud.Spanner.NHibernate.IntegrationTests.InterleavedTableTests.Entities;
+using System;
+using Xunit;
+
+namespace Google.Cloud.Spanner.NHibernate.IntegrationTests.InterleavedTableTests
+{
+    public class InterleavedTableTests : IClassFixture<SpannerInterleavedTableFixture>
+    {
+        private readonly SpannerInterleavedTableFixture _fixture;
+
+        public InterleavedTableTests(SpannerInterleavedTableFixture fixture) => _fixture = fixture;
+
+        [Fact]
+        public void CanCreateRows()
+        {
+            using var session = _fixture.SessionFactory.OpenSession();
+            using var transaction = session.BeginTransaction();
+            var singer = new Singer
+            {
+                FirstName = "Pete",
+                LastName = "Allison",
+            };
+            var singerId = session.Save(singer);
+            var album = new Album
+            {
+                AlbumIdentifier = new AlbumIdentifier(singer),
+                Title = "My first album"
+            };
+            var albumId =  session.Save(album);
+            var track = new Track
+            {
+                TrackIdentifier = new TrackIdentifier(album),
+                Title = "My first track",
+            };
+            var trackId = session.Save(track);
+            session.Flush();
+            session.Clear();
+
+            singer = session.Load<Singer>(singerId);
+            album = session.Load<Album>(albumId);
+            track = session.Load<Track>(trackId);
+            
+            Assert.Equal(singerId, singer.SingerId);
+            Assert.Equal("Pete", singer.FirstName);
+            Assert.Equal("Allison", singer.LastName);
+            Assert.Equal("My first album", album.Title);
+            
+            Assert.Equal(albumId, album.AlbumIdentifier);
+            Assert.Equal("My first album", album.Title);
+            
+            Assert.Equal(trackId, track.TrackIdentifier);
+            Assert.Equal("My first track", track.Title);
+            
+            Assert.Equal(singer.SingerId, album.Singer.SingerId);
+            Assert.Equal(singer.FirstName, album.Singer.FirstName);
+            Assert.Equal(singer.LastName, album.Singer.LastName);
+            
+            Assert.Equal(album.AlbumIdentifier, track.Album.AlbumIdentifier);
+            Assert.Equal(singer.SingerId, track.Album.Singer.SingerId);
+            Assert.Equal(singer.FirstName, track.Album.Singer.FirstName);
+            Assert.Equal(singer.LastName, track.Album.Singer.LastName);
+            
+            Assert.Collection(singer.Albums, album => Assert.Equal("My first album", album.Title));
+            Assert.Collection(album.Tracks, track => Assert.Equal("My first track", track.Title));
+            Assert.Collection(singer.Tracks, track => Assert.Equal("My first track", track.Title));
+            
+            transaction.Commit();
+        }
+
+        [Fact]
+        public void CanUpdateRows()
+        {
+            object singerId, albumId, trackId;
+            using (var session = _fixture.SessionFactory.OpenSession())
+            {
+                using var transaction = session.BeginTransaction();
+                var singer = new Singer
+                {
+                    FirstName = "Pete",
+                    LastName = "Allison",
+                };
+                singerId = session.Save(singer);
+                var album = new Album
+                {
+                    AlbumIdentifier = new AlbumIdentifier(singer),
+                    Title = "My first album"
+                };
+                albumId = session.Save(album);
+                trackId = session.Save(new Track
+                {
+                    TrackIdentifier = new TrackIdentifier(album),
+                    Title = "My first track",
+                });
+                transaction.Commit();
+            }
+
+            using (var session = _fixture.SessionFactory.OpenSession())
+            {
+                using var transaction = session.BeginTransaction();
+                var singer = session.Load<Singer>(singerId);
+                var album = session.Load<Album>(albumId);
+                var track = session.Load<Track>(trackId);
+
+                singer.LastName = "Allison-Peterson";
+                album.Title = "My second album";
+                track.Title = "My second track";
+                transaction.Commit();
+            }
+            
+            using (var session = _fixture.SessionFactory.OpenSession())
+            {
+                var singer = session.Load<Singer>(singerId);
+                var album = session.Load<Album>(albumId);
+                var track = session.Load<Track>(trackId);
+                Assert.Equal("Pete", singer.FirstName);
+                Assert.Equal("Allison-Peterson", singer.LastName);
+                Assert.Equal("My second album", album.Title);
+                Assert.Equal("My second track", track.Title);
+            }
+        }
+
+        [Fact]
+        public void CanDeleteRows()
+        {
+            object singerId, albumId, trackId;
+            using (var session = _fixture.SessionFactory.OpenSession())
+            {
+                using var transaction = session.BeginTransaction();
+                var singer = new Singer
+                {
+                    FirstName = "Pete",
+                    LastName = "Allison",
+                };
+                singerId = session.Save(singer);
+                var album = new Album
+                {
+                    AlbumIdentifier = new AlbumIdentifier(singer),
+                    Title = "My first album"
+                };
+                albumId = session.Save(album);
+                trackId = session.Save(new Track
+                {
+                    TrackIdentifier = new TrackIdentifier(album),
+                    Title = "My first track",
+                });
+                transaction.Commit();
+            }
+
+            using (var session = _fixture.SessionFactory.OpenSession())
+            {
+                using var transaction = session.BeginTransaction();
+                var singer = session.Load<Singer>(singerId);
+                var album = session.Load<Album>(albumId);
+                var track = session.Load<Track>(trackId);
+
+                session.Delete(track);
+                session.Delete(album);
+                session.Delete(singer);
+                transaction.Commit();
+            }
+            
+            using (var session = _fixture.SessionFactory.OpenSession())
+            {
+                var singer = session.Get<Singer>(singerId);
+                var album = session.Get<Album>(albumId);
+                var track = session.Get<Track>(trackId);
+                Assert.Null(singer);
+                Assert.Null(album);
+                Assert.Null(track);
+            }
+        }
+    }
+}

--- a/Google.Cloud.Spanner.NHibernate.IntegrationTests/InterleavedTableTests/SpannerInterleavedTableFixture.cs
+++ b/Google.Cloud.Spanner.NHibernate.IntegrationTests/InterleavedTableTests/SpannerInterleavedTableFixture.cs
@@ -1,0 +1,122 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+using Google.Cloud.Spanner.NHibernate.IntegrationTests.InterleavedTableTests.Entities;
+using Google.Cloud.Spanner.V1.Internal.Logging;
+using NHibernate;
+using NHibernate.Cfg;
+using NHibernate.Mapping.ByCode;
+using NHibernate.Util;
+using System;
+using System.IO;
+using System.Reflection;
+
+namespace Google.Cloud.Spanner.NHibernate.IntegrationTests.InterleavedTableTests
+{
+    /// <summary>
+    /// Test fixture using a data model with three hierarchical tables (Singers => Albums => Tracks).
+    /// </summary>
+    public class SpannerInterleavedTableFixture : SpannerFixtureBase
+    {
+        public SpannerInterleavedTableFixture()
+        {
+            if (Database.Fresh)
+            {
+                Logger.DefaultLogger.Debug($"Creating database {Database.DatabaseName}");
+                CreateTables();
+            }
+            else
+            {
+                Logger.DefaultLogger.Debug($"Deleting data in {Database.DatabaseName}");
+                ClearTables();
+            }
+            Logger.DefaultLogger.Debug($"Ready to run tests");
+            ReflectHelper.ClassForName(typeof(SpannerDriver).AssemblyQualifiedName);
+            var nhConfig = new Configuration().DataBaseIntegration(db =>
+            {
+                db.Dialect<SpannerDialect>();
+                db.ConnectionString = ConnectionString;
+                db.BatchSize = 100;
+            });
+            var mapper = new ModelMapper();
+            mapper.AddMapping<AlbumMapping>();
+            mapper.AddMapping<SingerMapping>();
+            mapper.AddMapping<TrackMapping>();
+            var mapping = mapper.CompileMappingForAllExplicitlyAddedEntities();
+            nhConfig.AddMapping(mapping);
+            
+            SessionFactory = nhConfig.BuildSessionFactory();
+        }
+        
+        public ISessionFactory SessionFactory { get; }
+
+        private void ClearTables()
+        {
+            using var con = GetConnection();
+            con.RunWithRetriableTransactionAsync((transaction) =>
+            {
+                var cmd = transaction.CreateBatchDmlCommand();
+                foreach (var table in new string[]
+                {
+                    "Tracks",
+                    "Albums",
+                    "Singers",
+                })
+                {
+                    cmd.Add($"DELETE FROM {table} WHERE TRUE");
+                }
+                return cmd.ExecuteNonQueryAsync();
+            }).ResultWithUnwrappedExceptions();
+        }
+
+        /// <summary>
+        /// Creates the sample data model. This method is only called when a new database has been
+        /// created.
+        /// </summary>
+        private void CreateTables()
+        {
+            var dirPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            var sampleModel = "InterleavedTableTests/InterleavedTableDataModel.sql";
+            var fileName = Path.Combine(dirPath, sampleModel);
+            var script = File.ReadAllText(fileName);
+            var statements = script.Split(";");
+            for (var i = 0; i < statements.Length; i++)
+            {
+                // Remove license header from script
+                if (statements[i].IndexOf("/*") >= 0 && statements[i].IndexOf("*/") >= 0)
+                {
+                    int startIndex = statements[i].IndexOf("/*");
+                    int endIndex = statements[i].IndexOf("*/", startIndex) + "*/".Length;
+                    statements[i] = statements[i].Remove(startIndex, endIndex - startIndex);
+                }
+                statements[i] = statements[i].Trim(new char[] { '\r', '\n' });
+            }
+            int length = statements.Length;
+            if (statements[length - 1] == "")
+            {
+                length--;
+            }
+            ExecuteDdl(statements, length);
+        }
+
+        private void ExecuteDdl(string[] ddl, int length)
+        {
+            string[] extraStatements = new string[length - 1];
+            Array.Copy(ddl, 1, extraStatements, 0, extraStatements.Length);
+            using var connection = GetConnection();
+            connection.CreateDdlCommand(ddl[0].Trim(), extraStatements).ExecuteNonQuery();
+        }
+    }
+}


### PR DESCRIPTION
Adds integration tests for interleaved table hierarchies. Interleaved tables can be used as any other many-to-one - one-to-many relationship, except that the reference cannot be updated as it is part of the primary key of the table.

cc @anshuldavid13 @AlexandrTrf @Rishabh-V
