### PR TITLE
deps: bump Spanner Data version to 3.13 and use release

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,9 +19,9 @@ jobs:
       run: dotnet restore
     - name: Build
       run: dotnet build --no-restore
-    - name: Unit Tests NHibernate
-      working-directory: ./Google.Cloud.Spanner.Hibernate.Tests
-      run: dotnet test --no-build --verbosity normal
     - name: Unit Tests Connection
       working-directory: ./Google.Cloud.Spanner.Connection.Tests
+      run: dotnet test --no-build --verbosity normal
+    - name: Unit Tests NHibernate
+      working-directory: ./Google.Cloud.Spanner.NHibernate.Tests
       run: dotnet test --no-build --verbosity normal

--- a/.github/workflows/integration-tests-on-emulator.yml
+++ b/.github/workflows/integration-tests-on-emulator.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       emulator:
-        image: gcr.io/cloud-spanner-emulator/emulator:1.3.0
+        image: gcr.io/cloud-spanner-emulator/emulator:latest
         ports:
           - 9010:9010
           - 9020:9020
@@ -33,4 +33,4 @@ jobs:
           JOB_TYPE: test
           SPANNER_EMULATOR_HOST: localhost:9010
           TEST_PROJECT: emulator-test-project
-          TEST_SPANNER_INSTANCE: test-instance
+          TEST_INSTANCE: test-instance

--- a/.github/workflows/integration-tests-on-emulator.yml
+++ b/.github/workflows/integration-tests-on-emulator.yml
@@ -31,7 +31,7 @@ jobs:
         run: dotnet build --no-restore
       - name: Integration Tests on Emulator
         working-directory: ./Google.Cloud.Spanner.NHibernate.IntegrationTests
-        run: dotnet test --no-build --verbosity normal --filter "FullyQualifiedName=Google.Cloud.Spanner.NHibernate.IntegrationTests.BasicsTests.CanInsertOrUpdateData"
+        run: dotnet test --no-build --verbosity normal --filter "FullyQualifiedName~Google.Cloud.Spanner.NHibernate.IntegrationTests.BasicsTests|FullyQualifiedName~Google.Cloud.Spanner.NHibernate.IntegrationTests.QueryTests"
         env:
           JOB_TYPE: test
           SPANNER_EMULATOR_HOST: localhost:9010

--- a/.github/workflows/integration-tests-on-emulator.yml
+++ b/.github/workflows/integration-tests-on-emulator.yml
@@ -31,7 +31,7 @@ jobs:
         run: dotnet test --no-build --verbosity normal
       - name: Integration Tests on Emulator
         working-directory: ./Google.Cloud.Spanner.NHibernate.IntegrationTests
-        run: dotnet test --verbosity normal
+        run: dotnet test --no-build --verbosity normal
         env:
           JOB_TYPE: test
           SPANNER_EMULATOR_HOST: localhost:9010

--- a/.github/workflows/integration-tests-on-emulator.yml
+++ b/.github/workflows/integration-tests-on-emulator.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       emulator:
-        image: gcr.io/cloud-spanner-emulator/emulator:latest
+        image: gcr.io/cloud-spanner-emulator/emulator:1.2.0
         ports:
           - 9010:9010
           - 9020:9020

--- a/.github/workflows/integration-tests-on-emulator.yml
+++ b/.github/workflows/integration-tests-on-emulator.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       emulator:
-        image: gcr.io/cloud-spanner-emulator/emulator:latest
+        image: gcr.io/cloud-spanner-emulator/emulator:1.3.0
         ports:
           - 9010:9010
           - 9020:9020

--- a/.github/workflows/integration-tests-on-emulator.yml
+++ b/.github/workflows/integration-tests-on-emulator.yml
@@ -31,7 +31,8 @@ jobs:
         run: dotnet build --no-restore
       - name: Integration Tests on Emulator
         working-directory: ./Google.Cloud.Spanner.NHibernate.IntegrationTests
-        run: dotnet test --no-build --verbosity normal --filter "FullyQualifiedName~Google.Cloud.Spanner.NHibernate.IntegrationTests.BasicsTests|FullyQualifiedName~Google.Cloud.Spanner.NHibernate.IntegrationTests.QueryTests"
+        # run: dotnet test --no-build --verbosity normal --filter "FullyQualifiedName~Google.Cloud.Spanner.NHibernate.IntegrationTests.BasicsTests|FullyQualifiedName~Google.Cloud.Spanner.NHibernate.IntegrationTests.QueryTests"
+        run: dotnet test --no-build --verbosity normal
         env:
           JOB_TYPE: test
           SPANNER_EMULATOR_HOST: localhost:9010

--- a/.github/workflows/integration-tests-on-emulator.yml
+++ b/.github/workflows/integration-tests-on-emulator.yml
@@ -1,0 +1,36 @@
+name: .NET
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  integration-tests-on-emulator:
+    runs-on: ubuntu-latest
+    services:
+      emulator:
+        image: gcr.io/cloud-spanner-emulator/emulator:latest
+        ports:
+          - 9010:9010
+          - 9020:9020
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 3.1.x
+      - name: Restore dependencies
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --no-restore
+      - name: Integration Tests on Emulator
+        working-directory: ./Google.Cloud.Spanner.NHibernate.IntegrationTests
+        run: dotnet test --verbosity normal
+        env:
+          JOB_TYPE: test
+          SPANNER_EMULATOR_HOST: localhost:9010
+          TEST_PROJECT: emulator-test-project
+          TEST_SPANNER_INSTANCE: test-instance

--- a/.github/workflows/integration-tests-on-emulator.yml
+++ b/.github/workflows/integration-tests-on-emulator.yml
@@ -28,9 +28,9 @@ jobs:
         run: dotnet build --no-restore
       - name: Integration Tests on Emulator
         working-directory: ./Google.Cloud.Spanner.NHibernate.IntegrationTests
-        run: dotnet test --verbosity normal
+        run: dotnet test --verbosity diag
         env:
           JOB_TYPE: test
-          SPANNER_EMULATOR_HOST: 127.0.0.1:9010
+          SPANNER_EMULATOR_HOST: localhost:9010
           TEST_PROJECT: emulator-test-project
           TEST_INSTANCE: test-instance

--- a/.github/workflows/integration-tests-on-emulator.yml
+++ b/.github/workflows/integration-tests-on-emulator.yml
@@ -36,4 +36,4 @@ jobs:
           JOB_TYPE: test
           SPANNER_EMULATOR_HOST: localhost:9010
           TEST_PROJECT: emulator-test-project
-          TEST_INSTANCE: test-instance
+          TEST_SPANNER_INSTANCE: test-instance

--- a/.github/workflows/integration-tests-on-emulator.yml
+++ b/.github/workflows/integration-tests-on-emulator.yml
@@ -9,12 +9,15 @@ on:
 jobs:
   integration-tests-on-emulator:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     services:
       emulator:
         image: gcr.io/cloud-spanner-emulator/emulator:latest
         ports:
           - 9010:9010
+          - 9010:9010/udp
           - 9020:9020
+          - 9020:9020/udp
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/integration-tests-on-emulator.yml
+++ b/.github/workflows/integration-tests-on-emulator.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   integration-tests-on-emulator:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 5
     services:
       emulator:
         image: gcr.io/cloud-spanner-emulator/emulator:latest
@@ -31,7 +31,7 @@ jobs:
         run: dotnet build --no-restore
       - name: Integration Tests on Emulator
         working-directory: ./Google.Cloud.Spanner.NHibernate.IntegrationTests
-        run: dotnet test --no-build --verbosity normal --filter "FullyQualifiedName~Google.Cloud.Spanner.NHibernate.IntegrationTests.BasicsTests|FullyQualifiedName~Google.Cloud.Spanner.NHibernate.IntegrationTests.QueryTests"
+        run: dotnet test --no-build --verbosity normal --filter "FullyQualifiedName~Google.Cloud.Spanner.NHibernate.IntegrationTests.QueryTests"
         env:
           JOB_TYPE: test
           SPANNER_EMULATOR_HOST: localhost:9010

--- a/.github/workflows/integration-tests-on-emulator.yml
+++ b/.github/workflows/integration-tests-on-emulator.yml
@@ -28,7 +28,7 @@ jobs:
         run: dotnet build --no-restore
       - name: Integration Tests on Emulator
         working-directory: ./Google.Cloud.Spanner.NHibernate.IntegrationTests
-        run: dotnet test --verbosity diag
+        run: dotnet test --verbosity normal
         env:
           JOB_TYPE: test
           SPANNER_EMULATOR_HOST: localhost:9010

--- a/.github/workflows/integration-tests-on-emulator.yml
+++ b/.github/workflows/integration-tests-on-emulator.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       emulator:
-        image: gcr.io/cloud-spanner-emulator/emulator:1.2.0
+        image: gcr.io/cloud-spanner-emulator/emulator:latest
         ports:
           - 9010:9010
           - 9020:9020
@@ -31,6 +31,6 @@ jobs:
         run: dotnet test --verbosity normal
         env:
           JOB_TYPE: test
-          SPANNER_EMULATOR_HOST: localhost:9010
+          SPANNER_EMULATOR_HOST: 127.0.0.1:9010
           TEST_PROJECT: emulator-test-project
           TEST_INSTANCE: test-instance

--- a/.github/workflows/integration-tests-on-emulator.yml
+++ b/.github/workflows/integration-tests-on-emulator.yml
@@ -29,12 +29,9 @@ jobs:
         run: dotnet restore
       - name: Build
         run: dotnet build --no-restore
-      - name: Unit Tests NHibernate
-        working-directory: ./Google.Cloud.Spanner.NHibernate.Tests
-        run: dotnet test --no-build --verbosity normal
       - name: Integration Tests on Emulator
         working-directory: ./Google.Cloud.Spanner.NHibernate.IntegrationTests
-        run: dotnet test --no-build --verbosity normal
+        run: dotnet test --no-build --verbosity normal --filter "FullyQualifiedName=Google.Cloud.Spanner.NHibernate.IntegrationTests.BasicsTests.CanInsertOrUpdateData"
         env:
           JOB_TYPE: test
           SPANNER_EMULATOR_HOST: localhost:9010

--- a/.github/workflows/integration-tests-on-emulator.yml
+++ b/.github/workflows/integration-tests-on-emulator.yml
@@ -31,7 +31,7 @@ jobs:
         run: dotnet build --no-restore
       - name: Integration Tests on Emulator
         working-directory: ./Google.Cloud.Spanner.NHibernate.IntegrationTests
-        run: dotnet test --no-build --verbosity normal --filter "FullyQualifiedName~Google.Cloud.Spanner.NHibernate.IntegrationTests.QueryTests"
+        run: dotnet test --no-build --verbosity normal --filter "FullyQualifiedName~Google.Cloud.Spanner.NHibernate.IntegrationTests.BasicsTests|FullyQualifiedName~Google.Cloud.Spanner.NHibernate.IntegrationTests.QueryTests"
         env:
           JOB_TYPE: test
           SPANNER_EMULATOR_HOST: localhost:9010

--- a/.github/workflows/integration-tests-on-emulator.yml
+++ b/.github/workflows/integration-tests-on-emulator.yml
@@ -26,6 +26,9 @@ jobs:
         run: dotnet restore
       - name: Build
         run: dotnet build --no-restore
+      - name: Unit Tests NHibernate
+        working-directory: ./Google.Cloud.Spanner.NHibernate.Tests
+        run: dotnet test --no-build --verbosity normal
       - name: Integration Tests on Emulator
         working-directory: ./Google.Cloud.Spanner.NHibernate.IntegrationTests
         run: dotnet test --verbosity normal

--- a/.github/workflows/integration-tests-on-emulator.yml
+++ b/.github/workflows/integration-tests-on-emulator.yml
@@ -31,7 +31,6 @@ jobs:
         run: dotnet build --no-restore
       - name: Integration Tests on Emulator
         working-directory: ./Google.Cloud.Spanner.NHibernate.IntegrationTests
-        # run: dotnet test --no-build --verbosity normal --filter "FullyQualifiedName~Google.Cloud.Spanner.NHibernate.IntegrationTests.BasicsTests|FullyQualifiedName~Google.Cloud.Spanner.NHibernate.IntegrationTests.QueryTests"
         run: dotnet test --no-build --verbosity normal
         env:
           JOB_TYPE: test

--- a/Google.Cloud.Spanner.Connection/Google.Cloud.Spanner.Connection.csproj
+++ b/Google.Cloud.Spanner.Connection/Google.Cloud.Spanner.Connection.csproj
@@ -8,4 +8,8 @@
       <ProjectReference Include="..\..\google-cloud-dotnet\apis\Google.Cloud.Spanner.Data\Google.Cloud.Spanner.Data\Google.Cloud.Spanner.Data.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+      <PackageReference Include="Google.Cloud.Spanner.Data" Version="3.13.0" />
+    </ItemGroup>
+
 </Project>

--- a/Google.Cloud.Spanner.Connection/Google.Cloud.Spanner.Connection.csproj
+++ b/Google.Cloud.Spanner.Connection/Google.Cloud.Spanner.Connection.csproj
@@ -5,10 +5,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\..\google-cloud-dotnet\apis\Google.Cloud.Spanner.Data\Google.Cloud.Spanner.Data\Google.Cloud.Spanner.Data.csproj" />
-    </ItemGroup>
-
-    <ItemGroup>
       <PackageReference Include="Google.Cloud.Spanner.Data" Version="3.13.0" />
     </ItemGroup>
 

--- a/Google.Cloud.Spanner.NHibernate.IntegrationTests/BasicsTests.cs
+++ b/Google.Cloud.Spanner.NHibernate.IntegrationTests/BasicsTests.cs
@@ -17,6 +17,7 @@ using Xunit;
 
 namespace Google.Cloud.Spanner.NHibernate.IntegrationTests
 {
+    [Collection(nameof(NonParallelTestCollection))]
     public class BasicsTests : IClassFixture<SingleTableFixture>
     {
         private readonly SingleTableFixture _fixture;

--- a/Google.Cloud.Spanner.NHibernate.IntegrationTests/InterleavedTableTests/InterleavedTableTests.cs
+++ b/Google.Cloud.Spanner.NHibernate.IntegrationTests/InterleavedTableTests/InterleavedTableTests.cs
@@ -17,6 +17,7 @@ using Xunit;
 
 namespace Google.Cloud.Spanner.NHibernate.IntegrationTests.InterleavedTableTests
 {
+    [Collection(nameof(NonParallelTestCollection))]
     public class InterleavedTableTests : IClassFixture<SpannerInterleavedTableFixture>
     {
         private readonly SpannerInterleavedTableFixture _fixture;

--- a/Google.Cloud.Spanner.NHibernate.IntegrationTests/QueryTests.cs
+++ b/Google.Cloud.Spanner.NHibernate.IntegrationTests/QueryTests.cs
@@ -26,6 +26,7 @@ using Xunit;
 
 namespace Google.Cloud.Spanner.NHibernate.IntegrationTests
 {
+    [Collection(nameof(NonParallelTestCollection))]
     public class QueryTests : IClassFixture<SpannerSampleFixture>
     {
         private readonly SpannerSampleFixture _fixture;

--- a/Google.Cloud.Spanner.NHibernate.IntegrationTests/QueryTests.cs
+++ b/Google.Cloud.Spanner.NHibernate.IntegrationTests/QueryTests.cs
@@ -26,7 +26,6 @@ using Xunit;
 
 namespace Google.Cloud.Spanner.NHibernate.IntegrationTests
 {
-    [Collection(nameof(NonParallelTestCollection))]
     public class QueryTests : IClassFixture<SpannerSampleFixture>
     {
         private readonly SpannerSampleFixture _fixture;

--- a/Google.Cloud.Spanner.NHibernate.IntegrationTests/TransactionTests.cs
+++ b/Google.Cloud.Spanner.NHibernate.IntegrationTests/TransactionTests.cs
@@ -26,6 +26,7 @@ using Xunit;
 
 namespace Google.Cloud.Spanner.NHibernate.IntegrationTests
 {
+    [Collection(nameof(NonParallelTestCollection))]
     public class TransactionTests : IClassFixture<SpannerSampleFixture>
     {
         private readonly SpannerSampleFixture _fixture;

--- a/Google.Cloud.Spanner.NHibernate.IntegrationTests/TransactionTests.cs
+++ b/Google.Cloud.Spanner.NHibernate.IntegrationTests/TransactionTests.cs
@@ -26,7 +26,6 @@ using Xunit;
 
 namespace Google.Cloud.Spanner.NHibernate.IntegrationTests
 {
-    [Collection(nameof(NonParallelTestCollection))]
     public class TransactionTests : IClassFixture<SpannerSampleFixture>
     {
         private readonly SpannerSampleFixture _fixture;

--- a/Google.Cloud.Spanner.NHibernate.IntegrationTests/xunit.runner.json
+++ b/Google.Cloud.Spanner.NHibernate.IntegrationTests/xunit.runner.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
     "parallelizeTestCollections": true,
-    "maxParallelThreads":  16
+    "maxParallelThreads":  1
 }

--- a/Google.Cloud.Spanner.NHibernate.IntegrationTests/xunit.runner.json
+++ b/Google.Cloud.Spanner.NHibernate.IntegrationTests/xunit.runner.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
     "parallelizeTestCollections": true,
-    "maxParallelThreads":  1
+    "maxParallelThreads":  16
 }

--- a/Google.Cloud.Spanner.NHibernate.IntegrationTests/xunit.runner.json
+++ b/Google.Cloud.Spanner.NHibernate.IntegrationTests/xunit.runner.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
-    "parallelizeTestCollections": true,
-    "maxParallelThreads":  16
+    "parallelizeTestCollections": false,
+    "maxParallelThreads":  1
 }

--- a/Google.Cloud.Spanner.NHibernate.IntegrationTests/xunit.runner.json
+++ b/Google.Cloud.Spanner.NHibernate.IntegrationTests/xunit.runner.json
@@ -1,0 +1,5 @@
+{
+    "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+    "parallelizeTestCollections": true,
+    "maxParallelThreads":  16
+}

--- a/Google.Cloud.Spanner.NHibernate.IntegrationTests/xunit.runner.json
+++ b/Google.Cloud.Spanner.NHibernate.IntegrationTests/xunit.runner.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
-    "parallelizeTestCollections": false,
-    "maxParallelThreads":  1
+    "parallelizeTestCollections": true,
+    "maxParallelThreads":  16
 }

--- a/Google.Cloud.Spanner.NHibernate.sln
+++ b/Google.Cloud.Spanner.NHibernate.sln
@@ -2,8 +2,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Spanner.NHibernate", "Google.Cloud.Spanner.NHibernate\Google.Cloud.Spanner.NHibernate.csproj", "{4CD54993-F98B-47E8-944E-D6EE9789FE15}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Spanner.Data", "..\google-cloud-dotnet\apis\Google.Cloud.Spanner.Data\Google.Cloud.Spanner.Data\Google.Cloud.Spanner.Data.csproj", "{22EDD242-B02C-42FB-8983-22D72D5DBBED}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Spanner.Connection", "Google.Cloud.Spanner.Connection\Google.Cloud.Spanner.Connection.csproj", "{87D0559B-08A6-4B52-B545-E8ABBD82838A}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Spanner.Connection.Tests", "Google.Cloud.Spanner.Connection.Tests\Google.Cloud.Spanner.Connection.Tests.csproj", "{91FC74D9-F003-4035-B13F-B9E892FE2A69}"
@@ -22,10 +20,6 @@ Global
 		{4CD54993-F98B-47E8-944E-D6EE9789FE15}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4CD54993-F98B-47E8-944E-D6EE9789FE15}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4CD54993-F98B-47E8-944E-D6EE9789FE15}.Release|Any CPU.Build.0 = Release|Any CPU
-		{22EDD242-B02C-42FB-8983-22D72D5DBBED}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{22EDD242-B02C-42FB-8983-22D72D5DBBED}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{22EDD242-B02C-42FB-8983-22D72D5DBBED}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{22EDD242-B02C-42FB-8983-22D72D5DBBED}.Release|Any CPU.Build.0 = Release|Any CPU
 		{87D0559B-08A6-4B52-B545-E8ABBD82838A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{87D0559B-08A6-4B52-B545-E8ABBD82838A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{87D0559B-08A6-4B52-B545-E8ABBD82838A}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/Google.Cloud.Spanner.NHibernate/SpannerConnectionProvider.cs
+++ b/Google.Cloud.Spanner.NHibernate/SpannerConnectionProvider.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Api.Gax;
 using Google.Cloud.Spanner.Connection;
 using Google.Cloud.Spanner.Data;
 using Grpc.Core;
@@ -31,6 +32,7 @@ namespace Google.Cloud.Spanner.NHibernate
             var connectionStringBuilder = new SpannerConnectionStringBuilder(connectionString, ChannelCredentials)
             {
                 SessionPoolManager = SpannerDriver.SessionPoolManager,
+                EmulatorDetection = EmulatorDetection.EmulatorOrProduction,
             };
             var spannerConnection = new SpannerConnection(connectionStringBuilder);
             return new SpannerRetriableConnection(spannerConnection);


### PR DESCRIPTION
Removes the Spanner.Data project from the solution and instead depends on the released
3.13 version of the Spanner.Data library.
