### PR TITLE
fix: mock server tests would always try to connect to emulator

### DIFF
--- a/.github/workflows/integration-tests-on-emulator.yml
+++ b/.github/workflows/integration-tests-on-emulator.yml
@@ -15,9 +15,7 @@ jobs:
         image: gcr.io/cloud-spanner-emulator/emulator:latest
         ports:
           - 9010:9010
-          - 9010:9010/udp
           - 9020:9020
-          - 9020:9020/udp
 
     steps:
       - uses: actions/checkout@v2
@@ -29,6 +27,13 @@ jobs:
         run: dotnet restore
       - name: Build
         run: dotnet build --no-restore
+      - name: Unit Tests NHibernate
+        # Also execute the unit tests with the SPANNER_EMULATOR_HOST env var enabled, to ensure that these tests do
+        # not try to execute against the emulator.
+        working-directory: ./Google.Cloud.Spanner.NHibernate.Tests
+        run: dotnet test --no-build --verbosity normal
+        env:
+          SPANNER_EMULATOR_HOST: localhost:9010
       - name: Integration Tests on Emulator
         working-directory: ./Google.Cloud.Spanner.NHibernate.IntegrationTests
         run: dotnet test --no-build --verbosity normal

--- a/Google.Cloud.Spanner.NHibernate.Tests/NHibernateMockServerFixture.cs
+++ b/Google.Cloud.Spanner.NHibernate.Tests/NHibernateMockServerFixture.cs
@@ -14,25 +14,16 @@
 
 using Google.Cloud.Spanner.Connection.MockServer;
 using Google.Cloud.Spanner.NHibernate.Tests.Entities;
-using Grpc.Core;
 using NHibernate;
 using NHibernate.Cfg;
-using NHibernate.Mapping;
 using NHibernate.Mapping.ByCode;
-using NHibernate.SqlCommand;
 using NHibernate.Util;
-using System;
 using Environment = NHibernate.Cfg.Environment;
 using PropertyGeneration = NHibernate.Mapping.PropertyGeneration;
 
 namespace Google.Cloud.Spanner.NHibernate.Tests
 {
     // ReSharper disable once ClassNeverInstantiated.Global
-    internal class TestConnectionProvider : SpannerConnectionProvider
-    {
-        public override ChannelCredentials ChannelCredentials { get => ChannelCredentials.Insecure; set => throw new InvalidOperationException(); }
-    }
-    
     public class NHibernateMockServerFixture : SpannerMockServerFixture
     {
         public NHibernateMockServerFixture()

--- a/Google.Cloud.Spanner.NHibernate.Tests/TestConnectionProvider.cs
+++ b/Google.Cloud.Spanner.NHibernate.Tests/TestConnectionProvider.cs
@@ -1,0 +1,28 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+using Grpc.Core;
+using System;
+
+namespace Google.Cloud.Spanner.NHibernate.Tests
+{
+    internal class TestConnectionProvider : SpannerConnectionProvider
+    {
+        public override ChannelCredentials ChannelCredentials { get => ChannelCredentials.Insecure; set => throw new InvalidOperationException(); }
+
+        // Always ignore the emulator settings, as we want to connect to a mock server.
+        protected override EmulatorDetection EmulatorDetection => EmulatorDetection.None;
+    }
+}

--- a/Google.Cloud.Spanner.NHibernate/SpannerConnectionProvider.cs
+++ b/Google.Cloud.Spanner.NHibernate/SpannerConnectionProvider.cs
@@ -27,12 +27,14 @@ namespace Google.Cloud.Spanner.NHibernate
     {
         public virtual ChannelCredentials ChannelCredentials { get; set; }
 
+        protected virtual EmulatorDetection EmulatorDetection => EmulatorDetection.EmulatorOrProduction;
+
         public override DbConnection GetConnection(string connectionString)
         {
             var connectionStringBuilder = new SpannerConnectionStringBuilder(connectionString, ChannelCredentials)
             {
                 SessionPoolManager = SpannerDriver.SessionPoolManager,
-                EmulatorDetection = EmulatorDetection.EmulatorOrProduction,
+                EmulatorDetection = EmulatorDetection,
             };
             var spannerConnection = new SpannerConnection(connectionStringBuilder);
             return new SpannerRetriableConnection(spannerConnection);


### PR DESCRIPTION
The mock server tests would always try to connect to the emulator if the
SPANNER_EMULATOR_HOST had been set. This would cause the tests to fail,
as the client would either send all requests to the emulator (if the emulator
was running), or to return an UNAVAILABLE exception when the emulator was not
running.
