### PR TITLE
fix: batch count was increased twice

### DIFF
--- a/Google.Cloud.Spanner.NHibernate/SpannerBatcher.cs
+++ b/Google.Cloud.Spanner.NHibernate/SpannerBatcher.cs
@@ -71,7 +71,6 @@ namespace Google.Cloud.Spanner.NHibernate
                 CheckReaders();
             }
 
-            _currentBatchStatementCount++;
             _totalExpectedRowsAffected += expectation.ExpectedRowCount;
             var batchUpdate = CurrentCommand as SpannerRetriableCommand;
             Prepare(batchUpdate);


### PR DESCRIPTION
Fixes a small error in the `SpannerBatcher` that would cause the batch count to be increased twice when the sync version was used. This would cause the actual batch size to be half of what it should be (that is; it had been set to 100, but could only contain 50 items).