### PR TITLE
feat: enable SchemaValidator usage

### DIFF
--- a/Google.Cloud.Spanner.Connection/SpannerRetriableConnection.cs
+++ b/Google.Cloud.Spanner.Connection/SpannerRetriableConnection.cs
@@ -277,6 +277,6 @@ namespace Google.Cloud.Spanner.Connection
 
         /// <inheritdoc/>
         public override DataTable GetSchema(string collectionName, string[] restrictionValues) =>
-            new SchemaProvider(this).GetSchema(collectionName);
+            new SchemaProvider(this).GetSchema(collectionName, restrictionValues);
     }
 }

--- a/Google.Cloud.Spanner.NHibernate.IntegrationTests/SchemaTests.cs
+++ b/Google.Cloud.Spanner.NHibernate.IntegrationTests/SchemaTests.cs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 using Google.Cloud.Spanner.Connection;
+using NHibernate;
+using NHibernate.Tool.hbm2ddl;
 using System.Data;
 using System.Threading.Tasks;
 using Xunit;
@@ -34,6 +36,16 @@ namespace Google.Cloud.Spanner.NHibernate.IntegrationTests
             exporter.Execute(false, true, false);
             
             VerifySchemaEquality(initialSchema, _fixture);
+
+            var validator = new SchemaValidator(_fixture.Configuration);
+            try
+            {
+                validator.Validate();
+            }
+            catch (SchemaValidationException e)
+            {
+                Assert.Empty(e.ValidationErrors);
+            }
         }
 
         [Fact]
@@ -45,6 +57,9 @@ namespace Google.Cloud.Spanner.NHibernate.IntegrationTests
             await exporter.ExecuteAsync(false, true, false);
             
             VerifySchemaEquality(initialSchema, _fixture);
+
+            var validator = new SchemaValidator(_fixture.Configuration);
+            await validator.ValidateAsync();
         }
 
         [Fact]

--- a/Google.Cloud.Spanner.NHibernate.IntegrationTests/SchemaTests.cs
+++ b/Google.Cloud.Spanner.NHibernate.IntegrationTests/SchemaTests.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using Google.Cloud.Spanner.Connection;
-using NHibernate;
 using NHibernate.Tool.hbm2ddl;
 using System.Data;
 using System.Threading.Tasks;
@@ -37,15 +36,9 @@ namespace Google.Cloud.Spanner.NHibernate.IntegrationTests
             
             VerifySchemaEquality(initialSchema, _fixture);
 
+            // Verify that the generated schema is also valid according to the built-in schema validator of NHibernate.
             var validator = new SchemaValidator(_fixture.Configuration);
-            try
-            {
-                validator.Validate();
-            }
-            catch (SchemaValidationException e)
-            {
-                Assert.Empty(e.ValidationErrors);
-            }
+            validator.Validate();
         }
 
         [Fact]
@@ -58,6 +51,7 @@ namespace Google.Cloud.Spanner.NHibernate.IntegrationTests
             
             VerifySchemaEquality(initialSchema, _fixture);
 
+            // Verify that the generated schema is also valid according to the built-in schema validator of NHibernate.
             var validator = new SchemaValidator(_fixture.Configuration);
             await validator.ValidateAsync();
         }


### PR DESCRIPTION
Enables the usage of `SchemaValidator`. This uses feature requires the `SchemaProvider` to also support restrictions when querying the meta model of the database, which is therefore also added in this PR.