### PR TITLE
fix: enable batching of versioned data by default

### DIFF
--- a/Google.Cloud.Spanner.NHibernate.Samples/Snippets/QueryHintSample.cs
+++ b/Google.Cloud.Spanner.NHibernate.Samples/Snippets/QueryHintSample.cs
@@ -16,7 +16,6 @@ using Google.Cloud.Spanner.NHibernate.Samples.SampleModel;
 using NHibernate.Criterion;
 using NHibernate.Linq;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Environment = NHibernate.Cfg.Environment;

--- a/Google.Cloud.Spanner.NHibernate.Tests/NHibernateVersioningMockServerTests.cs
+++ b/Google.Cloud.Spanner.NHibernate.Tests/NHibernateVersioningMockServerTests.cs
@@ -110,10 +110,10 @@ namespace Google.Cloud.Spanner.NHibernate.Tests
             _fixture.SpannerMock.AddOrUpdateStatementResult(updateSql, StatementResult.CreateUpdateCount(0L));
             _fixture.SpannerMock.AddOrUpdateStatementResult(selectSql, StatementResult.CreateResultSet(new List<Tuple<V1.TypeCode, string>>
             {
-                Tuple.Create(V1.TypeCode.Int64, "singerid1_4_0_"),
-                Tuple.Create(V1.TypeCode.Int64, "version2_4_0_"),
-                Tuple.Create(V1.TypeCode.String, "firstname3_4_0_"),
-                Tuple.Create(V1.TypeCode.String, "lastname4_4_0_")
+                Tuple.Create(TypeCode.Int64, "singerid1_4_0_"),
+                Tuple.Create(TypeCode.Int64, "version2_4_0_"),
+                Tuple.Create(TypeCode.String, "firstname3_4_0_"),
+                Tuple.Create(TypeCode.String, "lastname4_4_0_")
             }, new List<object[]>
             {
                 new object[]{"1", "1", "Pete", "Allison"}
@@ -125,7 +125,7 @@ namespace Google.Cloud.Spanner.NHibernate.Tests
                 {
                     var singer = await session.LoadAsync<SingerWithVersion>(1L);
                     singer.LastName = "Allison - Peterson";
-                    await Assert.ThrowsAsync<StaleObjectStateException>(() => session.FlushAsync());
+                    await Assert.ThrowsAsync<StaleStateException>(() => session.FlushAsync());
                     // Update the update count to 1 to simulate a resolved version conflict.
                     _fixture.SpannerMock.AddOrUpdateStatementResult(updateSql, StatementResult.CreateUpdateCount(1L));
                     await transaction.CommitAsync();

--- a/Google.Cloud.Spanner.NHibernate/SpannerDialect.cs
+++ b/Google.Cloud.Spanner.NHibernate/SpannerDialect.cs
@@ -31,7 +31,12 @@ namespace Google.Cloud.Spanner.NHibernate
         public SpannerDialect()
         {
 			DefaultProperties[Environment.ConnectionDriver] = typeof(SpannerDriver).AssemblyQualifiedName;
+			// Set BatchSize to 100 by default to ensure that batching is used unless the user explicitly turns it off.
+			// This will ensure that Batch DML is used as much as possible, and that mutations can be used.
 			DefaultProperties[Environment.BatchSize] = "100";
+			// Enable batching of versioned data. Batch DML returns the update count for each DML statement (including
+			// UPDATE and DELETE statements), which makes it safe to batch these statements as well.
+			DefaultProperties[Environment.BatchVersionedData] = "true";
 
 			RegisterDateTimeTypeMappings();
 			RegisterColumnType(DbType.AnsiStringFixedLength, "STRING(MAX)");


### PR DESCRIPTION
Enables batching of versioned data by default. This ensures that UPDATE and DELETE statements will
also be executed using Batch DML when they include a versioned entity.

Closes #61
