### PR TITLE
feat: use netstandard2.0 for libraries

### DIFF
--- a/Google.Cloud.Spanner.Connection.Tests/Google.Cloud.Spanner.Connection.Tests.csproj
+++ b/Google.Cloud.Spanner.Connection.Tests/Google.Cloud.Spanner.Connection.Tests.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
-
         <IsPackable>false</IsPackable>
+        <LangVersion>latest</LangVersion>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Google.Cloud.Spanner.Connection.Tests/MockServer/MockSpannerServer.cs
+++ b/Google.Cloud.Spanner.Connection.Tests/MockServer/MockSpannerServer.cs
@@ -706,13 +706,13 @@ namespace Google.Cloud.Spanner.Connection.MockServer
 
     public class MockDatabaseAdminService : DatabaseAdmin.DatabaseAdminBase
     {
-        private readonly ConcurrentQueue<IMessage> _requests = new ConcurrentQueue<IMessage>();
+        private ConcurrentQueue<IMessage> _requests = new ConcurrentQueue<IMessage>();
 
         public IEnumerable<IMessage> Requests => new List<IMessage>(_requests).AsReadOnly();
         
         public void Reset()
         {
-            _requests.Clear();
+            _requests = new ConcurrentQueue<IMessage>();
         }
 
         public override Task<Operation> CreateDatabase(CreateDatabaseRequest request, ServerCallContext context)

--- a/Google.Cloud.Spanner.Connection/Google.Cloud.Spanner.Connection.csproj
+++ b/Google.Cloud.Spanner.Connection/Google.Cloud.Spanner.Connection.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <LangVersion>latest</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Google.Cloud.Spanner.Connection/IRetriableStatement.cs
+++ b/Google.Cloud.Spanner.Connection/IRetriableStatement.cs
@@ -22,6 +22,6 @@ namespace Google.Cloud.Spanner.Connection
     /// </summary>
     internal interface IRetriableStatement
     {
-        internal Task RetryAsync(SpannerRetriableTransaction transaction, CancellationToken cancellationToken, int timeoutSeconds);
+        Task RetryAsync(SpannerRetriableTransaction transaction, CancellationToken cancellationToken, int timeoutSeconds);
     }
 }

--- a/Google.Cloud.Spanner.NHibernate.IntegrationTests/Google.Cloud.Spanner.NHibernate.IntegrationTests.csproj
+++ b/Google.Cloud.Spanner.NHibernate.IntegrationTests/Google.Cloud.Spanner.NHibernate.IntegrationTests.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
-
         <IsPackable>false</IsPackable>
+        <LangVersion>latest</LangVersion>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Google.Cloud.Spanner.NHibernate.IntegrationTests/InterleavedTableTests/SpannerInterleavedTableFixture.cs
+++ b/Google.Cloud.Spanner.NHibernate.IntegrationTests/InterleavedTableTests/SpannerInterleavedTableFixture.cs
@@ -92,7 +92,7 @@ namespace Google.Cloud.Spanner.NHibernate.IntegrationTests.InterleavedTableTests
             var sampleModel = "InterleavedTableTests/InterleavedTableDataModel.sql";
             var fileName = Path.Combine(dirPath, sampleModel);
             var script = File.ReadAllText(fileName);
-            var statements = script.Split(";");
+            var statements = script.Split(';');
             for (var i = 0; i < statements.Length; i++)
             {
                 // Remove license header from script

--- a/Google.Cloud.Spanner.NHibernate.IntegrationTests/SpannerSampleFixture.cs
+++ b/Google.Cloud.Spanner.NHibernate.IntegrationTests/SpannerSampleFixture.cs
@@ -130,7 +130,7 @@ namespace Google.Cloud.Spanner.NHibernate.IntegrationTests
             const string sampleModel = "SampleDataModel.sql";
             var fileName = Path.Combine(dirPath, sampleModel);
             var script = File.ReadAllText(fileName);
-            var statements = script.Split(";");
+            var statements = script.Split(';');
             for (var i = 0; i < statements.Length; i++)
             {
                 // Remove license header from script

--- a/Google.Cloud.Spanner.NHibernate.Samples/Google.Cloud.Spanner.NHibernate.Samples.csproj
+++ b/Google.Cloud.Spanner.NHibernate.Samples/Google.Cloud.Spanner.NHibernate.Samples.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <LangVersion>latest</LangVersion>
         <OutputType>Exe</OutputType>
         <TargetFramework>netcoreapp3.1</TargetFramework>
     </PropertyGroup>

--- a/Google.Cloud.Spanner.NHibernate.Samples/SampleRunner.cs
+++ b/Google.Cloud.Spanner.NHibernate.Samples/SampleRunner.cs
@@ -202,8 +202,8 @@ namespace Google.Cloud.Spanner.NHibernate.Samples
             var codeBasePath = Uri.UnescapeDataString(codeBaseUrl.AbsolutePath);
             var dirPath = Path.GetDirectoryName(codeBasePath) ?? "";
             var fileName = Path.Combine(dirPath, "SampleModel/SampleDataModel.sql");
-            var script = await File.ReadAllTextAsync(fileName);
-            var statements = script.Split(";");
+            var script = File.ReadAllText(fileName);
+            var statements = script.Split(';');
             for (var i = 0; i < statements.Length; i++)
             {
                 // Remove license header from script

--- a/Google.Cloud.Spanner.NHibernate.Tests/Google.Cloud.Spanner.NHibernate.Tests.csproj
+++ b/Google.Cloud.Spanner.NHibernate.Tests/Google.Cloud.Spanner.NHibernate.Tests.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
-
         <IsPackable>false</IsPackable>
+        <LangVersion>latest</LangVersion>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Google.Cloud.Spanner.NHibernate/Google.Cloud.Spanner.NHibernate.csproj
+++ b/Google.Cloud.Spanner.NHibernate/Google.Cloud.Spanner.NHibernate.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <LangVersion>latest</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Google.Cloud.Spanner.NHibernate/SpannerBatcher.cs
+++ b/Google.Cloud.Spanner.NHibernate/SpannerBatcher.cs
@@ -318,7 +318,7 @@ namespace Google.Cloud.Spanner.NHibernate
             }
             if (ownTransaction)
             {
-                await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+                transaction.Commit();
             }
             return rowsAffected;
         }

--- a/Google.Cloud.Spanner.NHibernate/SpannerBoolArray.cs
+++ b/Google.Cloud.Spanner.NHibernate/SpannerBoolArray.cs
@@ -37,7 +37,7 @@ namespace Google.Cloud.Spanner.NHibernate
         public override System.Type ReturnedType => typeof(SpannerBoolArray);
 
         public override object NullSafeGet(DbDataReader rs, string[] names, ISessionImplementor session, object owner) => 
-            rs.IsDBNull(names[0]) ? null : new SpannerBoolArray(rs.GetFieldValue<List<bool?>>(names[0]));
+            rs.IsDBNull(rs.GetOrdinal(names[0])) ? null : new SpannerBoolArray(rs.GetFieldValue<List<bool?>>(rs.GetOrdinal(names[0])));
 
         public override object DeepCopy(object value)
         {

--- a/Google.Cloud.Spanner.NHibernate/SpannerBytesArray.cs
+++ b/Google.Cloud.Spanner.NHibernate/SpannerBytesArray.cs
@@ -37,7 +37,7 @@ namespace Google.Cloud.Spanner.NHibernate
         public override System.Type ReturnedType => typeof(SpannerBytesArray);
 
         public override object NullSafeGet(DbDataReader rs, string[] names, ISessionImplementor session, object owner) => 
-            rs.IsDBNull(names[0]) ? null : new SpannerBytesArray(rs.GetFieldValue<List<byte[]>>(names[0]));
+            rs.IsDBNull(rs.GetOrdinal(names[0])) ? null : new SpannerBytesArray(rs.GetFieldValue<List<byte[]>>(rs.GetOrdinal(names[0])));
 
         public override object DeepCopy(object value)
         {

--- a/Google.Cloud.Spanner.NHibernate/SpannerDate.cs
+++ b/Google.Cloud.Spanner.NHibernate/SpannerDate.cs
@@ -154,7 +154,7 @@ namespace Google.Cloud.Spanner.NHibernate
         public int GetHashCode(object x) => x?.GetHashCode() ?? 0;
 
         public object NullSafeGet(DbDataReader rs, string[] names, ISessionImplementor session, object owner) => 
-            rs.IsDBNull(names[0]) ? null : FromDateTime(rs.GetFieldValue<DateTime>(names[0]));
+            rs.IsDBNull(rs.GetOrdinal(names[0])) ? null : FromDateTime(rs.GetFieldValue<DateTime>(rs.GetOrdinal(names[0])));
 
         public void NullSafeSet(DbCommand cmd, object value, int index, ISessionImplementor session)
         {

--- a/Google.Cloud.Spanner.NHibernate/SpannerDateArray.cs
+++ b/Google.Cloud.Spanner.NHibernate/SpannerDateArray.cs
@@ -38,7 +38,7 @@ namespace Google.Cloud.Spanner.NHibernate
         public override System.Type ReturnedType => typeof(SpannerDateArray);
 
         public override object NullSafeGet(DbDataReader rs, string[] names, ISessionImplementor session, object owner) => 
-            rs.IsDBNull(names[0]) ? null : new SpannerDateArray(rs.GetFieldValue<List<DateTime?>>(names[0]));
+            rs.IsDBNull(rs.GetOrdinal(names[0])) ? null : new SpannerDateArray(rs.GetFieldValue<List<DateTime?>>(rs.GetOrdinal(names[0])));
 
         public override object DeepCopy(object value)
         {

--- a/Google.Cloud.Spanner.NHibernate/SpannerFloat64Array.cs
+++ b/Google.Cloud.Spanner.NHibernate/SpannerFloat64Array.cs
@@ -37,7 +37,7 @@ namespace Google.Cloud.Spanner.NHibernate
         public override System.Type ReturnedType => typeof(SpannerFloat64Array);
 
         public override object NullSafeGet(DbDataReader rs, string[] names, ISessionImplementor session, object owner) => 
-            rs.IsDBNull(names[0]) ? null : new SpannerFloat64Array(rs.GetFieldValue<List<double?>>(names[0]));
+            rs.IsDBNull(rs.GetOrdinal(names[0])) ? null : new SpannerFloat64Array(rs.GetFieldValue<List<double?>>(rs.GetOrdinal(names[0])));
 
         public override object DeepCopy(object value)
         {

--- a/Google.Cloud.Spanner.NHibernate/SpannerInt64Array.cs
+++ b/Google.Cloud.Spanner.NHibernate/SpannerInt64Array.cs
@@ -37,7 +37,7 @@ namespace Google.Cloud.Spanner.NHibernate
         public override System.Type ReturnedType => typeof(SpannerInt64Array);
 
         public override object NullSafeGet(DbDataReader rs, string[] names, ISessionImplementor session, object owner) => 
-            rs.IsDBNull(names[0]) ? null : new SpannerInt64Array(rs.GetFieldValue<List<long?>>(names[0]));
+            rs.IsDBNull(rs.GetOrdinal(names[0])) ? null : new SpannerInt64Array(rs.GetFieldValue<List<long?>>(rs.GetOrdinal(names[0])));
 
         public override object DeepCopy(object value)
         {

--- a/Google.Cloud.Spanner.NHibernate/SpannerJson.cs
+++ b/Google.Cloud.Spanner.NHibernate/SpannerJson.cs
@@ -56,7 +56,7 @@ namespace Google.Cloud.Spanner.NHibernate
         public int GetHashCode(object x) => x?.GetHashCode() ?? 0;
 
         public object NullSafeGet(DbDataReader rs, string[] names, ISessionImplementor session, object owner) => 
-            rs.IsDBNull(names[0]) ? null : new SpannerJson(rs.GetFieldValue<string>(names[0]));
+            rs.IsDBNull(rs.GetOrdinal(names[0])) ? null : new SpannerJson(rs.GetFieldValue<string>(rs.GetOrdinal(names[0])));
 
         public void NullSafeSet(DbCommand cmd, object value, int index, ISessionImplementor session)
         {

--- a/Google.Cloud.Spanner.NHibernate/SpannerJsonArray.cs
+++ b/Google.Cloud.Spanner.NHibernate/SpannerJsonArray.cs
@@ -37,7 +37,7 @@ namespace Google.Cloud.Spanner.NHibernate
         public override System.Type ReturnedType => typeof(SpannerJsonArray);
 
         public override object NullSafeGet(DbDataReader rs, string[] names, ISessionImplementor session, object owner) => 
-            rs.IsDBNull(names[0]) ? null : new SpannerJsonArray(rs.GetFieldValue<List<string>>(names[0]));
+            rs.IsDBNull(rs.GetOrdinal(names[0])) ? null : new SpannerJsonArray(rs.GetFieldValue<List<string>>(rs.GetOrdinal(names[0])));
 
         public override object DeepCopy(object value)
         {

--- a/Google.Cloud.Spanner.NHibernate/SpannerNumeric.cs
+++ b/Google.Cloud.Spanner.NHibernate/SpannerNumeric.cs
@@ -56,7 +56,7 @@ namespace Google.Cloud.Spanner.NHibernate
         public int GetHashCode(object x) => x?.GetHashCode() ?? 0;
 
         public object NullSafeGet(DbDataReader rs, string[] names, ISessionImplementor session, object owner) => 
-            rs.IsDBNull(names[0]) ? null : new SpannerNumeric(rs.GetFieldValue<Cloud.Spanner.V1.SpannerNumeric>(names[0]));
+            rs.IsDBNull(rs.GetOrdinal(names[0])) ? null : new SpannerNumeric(rs.GetFieldValue<Cloud.Spanner.V1.SpannerNumeric>(rs.GetOrdinal(names[0])));
 
         public void NullSafeSet(DbCommand cmd, object value, int index, ISessionImplementor session)
         {

--- a/Google.Cloud.Spanner.NHibernate/SpannerNumericArray.cs
+++ b/Google.Cloud.Spanner.NHibernate/SpannerNumericArray.cs
@@ -37,8 +37,8 @@ namespace Google.Cloud.Spanner.NHibernate
         public override System.Type ReturnedType => typeof(SpannerNumericArray);
 
         public override object NullSafeGet(DbDataReader rs, string[] names, ISessionImplementor session, object owner) => 
-            rs.IsDBNull(names[0]) ? null : new SpannerNumericArray(
-                rs.GetFieldValue<List<Cloud.Spanner.V1.SpannerNumeric?>>(names[0]));
+            rs.IsDBNull(rs.GetOrdinal(names[0])) ? null : new SpannerNumericArray(
+                rs.GetFieldValue<List<Cloud.Spanner.V1.SpannerNumeric?>>(rs.GetOrdinal(names[0])));
 
         public override object DeepCopy(object value)
         {

--- a/Google.Cloud.Spanner.NHibernate/SpannerSchemaExport.cs
+++ b/Google.Cloud.Spanner.NHibernate/SpannerSchemaExport.cs
@@ -20,6 +20,7 @@ using NHibernate.Dialect;
 using NHibernate.Id;
 using NHibernate.Mapping;
 using NHibernate.Tool.hbm2ddl;
+using NHibernate.Util;
 using System;
 using System.Collections.Generic;
 using System.Data.Common;
@@ -365,8 +366,9 @@ namespace Google.Cloud.Spanner.NHibernate
             // We cannot get the auxiliary objects that have already been added to the config, so we have to use a
             // custom property to remember that.
             // We also convert all unique keys into unique indexes.
-            if (configuration.Properties.TryAdd("spanner.auxiliary.indexes", "true"))
+            if (!configuration.Properties.ContainsKey("spanner.auxiliary.indexes"))
             {
+                configuration.Properties.Add("spanner.auxiliary.indexes", "true");
                 foreach (var mapping in configuration.ClassMappings)
                 {
                     foreach (var index in mapping.Table.IndexIterator)

--- a/Google.Cloud.Spanner.NHibernate/SpannerSingleTableEntityPersister.cs
+++ b/Google.Cloud.Spanner.NHibernate/SpannerSingleTableEntityPersister.cs
@@ -260,7 +260,7 @@ namespace Google.Cloud.Spanner.NHibernate
 		        }
 		        if (inWhereClause)
 		        {
-			        if (content.EndsWith('='))
+			        if (content.EndsWith("="))
 			        {
 				        var column = ExtractColumnNameFromUpdateStatementPart(content, table);
 				        if (!column.Equals(VersionColumnName, StringComparison.InvariantCultureIgnoreCase))
@@ -280,7 +280,7 @@ namespace Google.Cloud.Spanner.NHibernate
 		        }
 		        else
 		        {
-			        if (content.EndsWith('='))
+			        if (content.EndsWith("="))
 			        {
 				        columns.Add(ExtractColumnNameFromUpdateStatementPart(content, table));
 			        }
@@ -357,19 +357,19 @@ namespace Google.Cloud.Spanner.NHibernate
 	        var updatePrefix = $"UPDATE {table} SET ";
 	        var wherePrefix = "WHERE ";
 	        var andPrefix = "AND ";
-	        if (part.StartsWith(',') && part.EndsWith('='))
+	        if (part.StartsWith(",") && part.EndsWith("="))
 	        {
 		        column = part.Substring(1, part.Length-2);
 	        }
-	        else if (part.StartsWith(wherePrefix) && part.EndsWith('='))
+	        else if (part.StartsWith(wherePrefix) && part.EndsWith("="))
 	        {
 		        column = part.Substring(wherePrefix.Length, part.Length - wherePrefix.Length - 1);
 	        }
-	        else if (part.StartsWith(andPrefix) && part.EndsWith('='))
+	        else if (part.StartsWith(andPrefix) && part.EndsWith("="))
 	        {
 		        column = part.Substring(andPrefix.Length, part.Length - andPrefix.Length - 1);
 	        }
-	        else if (part.EndsWith('=') && (index = part.LastIndexOf(updatePrefix, StringComparison.InvariantCultureIgnoreCase)) > -1)
+	        else if (part.EndsWith("=") && (index = part.LastIndexOf(updatePrefix, StringComparison.InvariantCultureIgnoreCase)) > -1)
 	        {
 		        column = part.Substring(index + updatePrefix.Length, part.Length - updatePrefix.Length - index - 1);
 	        }

--- a/Google.Cloud.Spanner.NHibernate/SpannerStringArray.cs
+++ b/Google.Cloud.Spanner.NHibernate/SpannerStringArray.cs
@@ -37,7 +37,7 @@ namespace Google.Cloud.Spanner.NHibernate
         public override System.Type ReturnedType => typeof(SpannerStringArray);
 
         public override object NullSafeGet(DbDataReader rs, string[] names, ISessionImplementor session, object owner) => 
-            rs.IsDBNull(names[0]) ? null : new SpannerStringArray(rs.GetFieldValue<List<string>>(names[0]));
+            rs.IsDBNull(rs.GetOrdinal(names[0])) ? null : new SpannerStringArray(rs.GetFieldValue<List<string>>(rs.GetOrdinal(names[0])));
 
         public override object DeepCopy(object value)
         {

--- a/Google.Cloud.Spanner.NHibernate/SpannerTimestampArray.cs
+++ b/Google.Cloud.Spanner.NHibernate/SpannerTimestampArray.cs
@@ -38,7 +38,7 @@ namespace Google.Cloud.Spanner.NHibernate
         public override System.Type ReturnedType => typeof(SpannerTimestampArray);
 
         public override object NullSafeGet(DbDataReader rs, string[] names, ISessionImplementor session, object owner) => 
-            rs.IsDBNull(names[0]) ? null : new SpannerTimestampArray(rs.GetFieldValue<List<DateTime?>>(names[0]));
+            rs.IsDBNull(rs.GetOrdinal(names[0])) ? null : new SpannerTimestampArray(rs.GetFieldValue<List<DateTime?>>(rs.GetOrdinal(names[0])));
 
         public override object DeepCopy(object value)
         {


### PR DESCRIPTION
Use netstandard2.0 as the target framework for the class libraries to ensure compatibility with
both .NET Framework and .NET Core versions. The complete list of supported versions can be found here: https://docs.microsoft.com/en-us/dotnet/standard/net-standard
